### PR TITLE
Allow to return available country codes

### DIFF
--- a/sinkien.IBAN4Net.Tests/CountryCodeTest.cs
+++ b/sinkien.IBAN4Net.Tests/CountryCodeTest.cs
@@ -20,6 +20,8 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace sinkien.IBAN4Net.Tests
@@ -76,5 +78,11 @@ namespace sinkien.IBAN4Net.Tests
             Assert.AreEqual( "CZE", entry.Alpha3 );
         }
 
+        [TestMethod]
+        public void GetAvailableCountryCodes()
+        {
+            IEnumerable<CountryCodeEntry> entries = CountryCode.GetCountryCodes();
+            Assert.AreEqual(251, entries.Count());
+        }
     }
 }

--- a/sinkien.IBAN4Net/CountryCode.cs
+++ b/sinkien.IBAN4Net/CountryCode.cs
@@ -65,6 +65,17 @@ namespace sinkien.IBAN4Net
             return result;
         }
 
+        /// <summary>
+        /// Gets available CountryCode objects from map
+        /// </summary>
+        /// <returns>Available CountryCodeItem objects</returns>
+        public static IEnumerable<CountryCodeEntry> GetCountryCodes ()
+        {
+            CountryCode cc = new CountryCode();
+
+            return cc._alpha3Map.Select(m => m.Value);
+        }
+
         private  CountryCodeEntry getByAlpha2 (string code)
         {
             CountryCodeEntry result = null;


### PR DESCRIPTION
I think it would be really useful to let users of the library know which country codes are available.  
The use case I am thinking about is having a combobox that comes prefilled with country codes, to help users build a valid IBAN.  
So I added a new method in `CountryCode `that returns the `_alpha3Map` as an `IEnumerable<CountryCode>`.  
Some performance improvements can be made if needed, as caching the calculated result so it can be returned immediately after the first calculation.  
If you want me to implement this change just let me know, I'll be happy to do so.